### PR TITLE
Show MindRoom team response in post

### DIFF
--- a/content/post/mindroom/index.md
+++ b/content/post/mindroom/index.md
@@ -206,9 +206,9 @@ You ask a question, the lead delegates subtasks, collects results, and synthesiz
 The system then merges their responses with a consensus summary.
 
 In practice, you might have a research team where one agent searches academic papers, another checks industry news, and a third validates claims—all triggered by a single message.
-The live room view below is the same Matrix thread surface those team runs use: threads, routed agents, and room history are all first-class chat objects rather than a separate dashboard.
+The live room view below shows a real team response in the same Matrix thread surface normal agents use: threads, routed agents, and room history are all first-class chat objects rather than a separate dashboard.
 
-{{< figure src="mindroom-team.png" caption="Live Personal room thread list and thread surface from chat.mindroom.chat. Team collaboration uses this same Matrix-native interface, with routed agents and shared history living in the room instead of a separate workflow UI." alt="Live MindRoom Personal room showing the Explain how MindRoom thread, routed agent activity, recent threads, and the room member list." >}}
+{{< figure src="mindroom-team.png" caption="Live Lobby thread in chat.mindroom.chat showing a real Team Response from HomeAssistant and AgentBuilder. Team collaboration uses the same Matrix-native interface as regular agent chats, with routed agents and room membership visible beside the conversation." alt="Live MindRoom Lobby thread showing a Team Response from HomeAssistant and AgentBuilder, with the member list showing Super Team and other agents." >}}
 
 ## 8. Hot-reload: change config and plugins without downtime
 

--- a/content/post/mindroom/mindroom-team.png
+++ b/content/post/mindroom/mindroom-team.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52652bcca873b2b955bcae10a61e118239170c5c09f9d695eb766d064b90ab95
-size 1063089
+oid sha256:0501f661cca4a1ada4475648ab3d527a1fb50a2c42b426521a8d764930fcd021
+size 591607


### PR DESCRIPTION
## Summary
- Replace the duplicate MindRoom team screenshot with a cropped native-resolution capture from the live chat.mindroom.chat frontend showing a real Team Response
- Update the Teams section copy/caption/alt text to match the new Lobby team-response image

## Verification
- devbox run build