### PR TITLE
Update NAS post with Time Machine validation

### DIFF
--- a/content/post/truenas-to-nixos/index.md
+++ b/content/post/truenas-to-nixos/index.md
@@ -448,13 +448,13 @@ The slow work was making the cutover boring.
   <li>the PC NFS mounts, Nix cache endpoints, and recovered Docker workload container all needed client-side validation.</li>
 </ul>
 
-<p>Those findings went back into the cutover runbooks and the Nix config, so the notes are available for anyone who might benefit from them later.</p>
+<p>Those findings went back into the cutover runbooks and the Nix config in a <a href="https://github.com/basnijholt/dotfiles/pull/62">follow-up PR</a>, so the notes are available for anyone who might benefit from them later.</p>
 
 </details>
 
 At the end of the cutover, the machine was `nas`, the ZFS pools were healthy, the NFS mounts worked from my PC, the Incus containers were recovered, and the Docker workloads were running again.
-SMB authentication, guest access, and Time Machine worked after one final share-root permission fix.
-Normal authenticated media access still deserves the usual client check, but the scary storage part is done.
+SMB authentication, guest access, Time Machine, and normal media browsing from macOS Finder worked after one final share-root permission fix.
+At that point the migration was working end to end: the pools were healthy and the services I actually use were back.
 
 ## References
 

--- a/content/post/truenas-to-nixos/index.md
+++ b/content/post/truenas-to-nixos/index.md
@@ -453,7 +453,8 @@ The slow work was making the cutover boring.
 </details>
 
 At the end of the cutover, the machine was `nas`, the ZFS pools were healthy, the NFS mounts worked from my PC, the Incus containers were recovered, and the Docker workloads were running again.
-SMB still deserves real client testing, especially Time Machine and normal authenticated photo/media access, but the scary storage part is done.
+SMB authentication, guest access, and Time Machine worked after one final share-root permission fix.
+Normal authenticated media access still deserves the usual client check, but the scary storage part is done.
 
 ## References
 


### PR DESCRIPTION
## Summary
- update the TrueNAS-to-NixOS post now that SMB auth, guest access, Time Machine, and macOS Finder media browsing have been validated
- mention that Time Machine needed one final share-root permission fix
- replace the stale remaining-media-check caveat with the current end-to-end post-cutover state

## Validation
- `git diff --check -- content/post/truenas-to-nixos/index.md`
- `devbox run build` exits 0

Note: the local build still prints the pre-existing Hugo warning `Failed to write jsconfig.json: ... assets/jsconfig.json: permission denied`, but the build exits successfully and this PR does not stage that untracked file.
